### PR TITLE
fix bug by setting inflow and outflow on containers

### DIFF
--- a/src/actors/prefabs.ts
+++ b/src/actors/prefabs.ts
@@ -13,6 +13,8 @@ import { colors, chars } from "./graphics";
 const fluidContainerComponent = {
   corked: false,
   maxVolume: 10,
+  inflow: true,
+  outflow: true,
   fluids: {
     water: {
       type: Fluids.Water,
@@ -224,6 +226,8 @@ export const ratPrefab: Entity = {
   fluidContainer: {
     corked: true,
     maxVolume: 10,
+    outflow: true,
+    inflow: false,
     fluids: {
       blood: {
         type: Fluids.Blood,
@@ -322,6 +326,8 @@ export const livingSpongePrefab: Entity = {
     ...fluidContainerComponent,
     corked: true,
     maxVolume: 2,
+    inflow: false,
+    outflow: true,
   },
   renderFluidColor: true,
 };
@@ -415,6 +421,8 @@ export const bottlePrefab: Entity = {
   fluidContainer: {
     ...fluidContainerComponent,
     corked: true,
+    inflow: false,
+    outflow: false,
   },
   mutable: {
     current: "empty",

--- a/src/ecs/engine.ts
+++ b/src/ecs/engine.ts
@@ -112,6 +112,8 @@ export interface FluidContainer {
   maxVolume: number;
   renderFluidColor?: true;
   fluids: Record<string, Fluid>;
+  outflow?: boolean;
+  inflow?: boolean;
 }
 
 export type EntityId = string;

--- a/src/ecs/systems/fluid.system.ts
+++ b/src/ecs/systems/fluid.system.ts
@@ -82,14 +82,18 @@ export const createFluidSystem = ({ world, registry }: IGameWorld) => {
             flow = Math.min(flow, maxDrain, space);
             if (flow <= EPSILON_FLOW) continue;
 
-            // Apply deltas
-            deltas[actor.id] ??= {};
-            deltas[actor.id][fluidType] =
-              (deltas[actor.id][fluidType] || 0) - flow;
+            if (actor.fluidContainer.outflow && entity.fluidContainer.inflow) {
+              // Apply deltas
+              // outflow
+              deltas[actor.id] ??= {};
+              deltas[actor.id][fluidType] =
+                (deltas[actor.id][fluidType] || 0) - flow;
 
-            deltas[entity.id] ??= {};
-            deltas[entity.id][fluidType] =
-              (deltas[entity.id][fluidType] || 0) + flow;
+              // inflow
+              deltas[entity.id] ??= {};
+              deltas[entity.id][fluidType] =
+                (deltas[entity.id][fluidType] || 0) + flow;
+            }
           }
         }
       }
@@ -114,12 +118,6 @@ export const createFluidSystem = ({ world, registry }: IGameWorld) => {
         // Numerical stability
         if (f.volume < EPSILON_FLOW) f.volume = 0;
         if (f.volume < 0) f.volume = 0;
-
-        // Lava interactions
-        if (fluidType === "lava") {
-          if (c.fluids.water) c.fluids.water.volume = 0;
-          if (c.fluids.blood) c.fluids.blood.volume = 0;
-        }
       }
     }
 
@@ -155,6 +153,10 @@ export const createFluidSystem = ({ world, registry }: IGameWorld) => {
               age: 0,
               source: true,
             });
+            // Lava interactions (lava deletes other fluid
+            if (c.fluids.water) c.fluids.water.volume = 0;
+            if (c.fluids.blood) c.fluids.blood.volume = 0;
+
             break;
         }
       }


### PR DESCRIPTION
Ensure that entities like rats are not liquid sinks upon death. This fixes a bug where rats upon death became blood fountains spilling blood forever from another dimension??

This ensures that a dead rat cannot both be filled with blood and spill blood.

The real issue is caused by having multiple fluid containers with bi-directional flow in the same location. This prevents that.

- closes #47