### PR TITLE
[fix] missing rat smell

### DIFF
--- a/src/ecs/systems/odor.system.ts
+++ b/src/ecs/systems/odor.system.ts
@@ -8,7 +8,9 @@ import { some } from "lodash";
 export const createOdorSystem = (gameWorld: IGameWorld) => {
   const { world, registry } = gameWorld;
   const odorQuery = world.with("odor", "position").without("excludeFromSim");
-  const blockingQuery = world.with("blocking", "position").without("excludeFromSim");
+  const blockingQuery = world
+    .with("blocking", "position")
+    .without("excludeFromSim");
   const pathThroughQuery = world
     .with("blocking", "position", "pathThrough")
     .without("excludeFromSim");
@@ -56,6 +58,7 @@ export const createOdorSystem = (gameWorld: IGameWorld) => {
       for (const eid of eap) {
         const entity = registry.get(eid);
         if (
+          entity?.id !== actor.id &&
           entity?.fluidContainer &&
           some(entity.fluidContainer.fluids, (fluid) => fluid.volume > 0)
         ) {


### PR DESCRIPTION
rats lost their smell because they now have a fluid container for blood. The odor system does a sort of hack to check if an entity is in water by checking all entities at it's position. If anything has a fluid container and contains any fluid, the smell cannot propagate. So rats were basically standing in their own blood. 

All of this should be improved in the future but for now - rats stink again.

- closes #63 