### PR TITLE
[fix] avoid empty origin when container spills

### DIFF
--- a/src/actors/prefabs.ts
+++ b/src/actors/prefabs.ts
@@ -289,8 +289,6 @@ export const lavaGolemPrefab: Entity = {
     fluids: {
       lava: {
         ...fluidContainerComponent.fluids.lava,
-        viscosity: 0.01,
-        minFlow: 1,
         volume: 8,
       },
     },

--- a/src/ecs/systems/fluid.system.ts
+++ b/src/ecs/systems/fluid.system.ts
@@ -35,11 +35,14 @@ export const createFluidSystem = ({ world, registry }: IGameWorld) => {
         continue;
       }
 
-      const fluidBudget = Object.keys(a.fluids).reduce((acc, cur) => {
-        const fluid = a.fluids[cur];
-        acc[fluid.type] = Math.max(fluid.volume - fluid.minFlow, 0);
-        return acc;
-      }, {} as Record<string, number>);
+      const fluidBudget = Object.keys(a.fluids).reduce(
+        (acc, cur) => {
+          const fluid = a.fluids[cur];
+          acc[cur] = Math.max(fluid.volume - fluid.minFlow, 0);
+          return acc;
+        },
+        {} as Record<string, number>,
+      );
 
       const neighbors = [
         actor.position,
@@ -77,9 +80,6 @@ export const createFluidSystem = ({ world, registry }: IGameWorld) => {
 
             let flow = (aFluid.volume - bFluid.volume) * rate;
 
-            // Do not flow if there isn't enough budget
-            if (flow > fluidBudget[fluidType]) continue;
-
             // Do not drain below residue
             const maxDrain = aFluid.volume - aFluid.minFlow;
             if (maxDrain <= 0) continue;
@@ -91,6 +91,9 @@ export const createFluidSystem = ({ world, registry }: IGameWorld) => {
 
             flow = Math.min(flow, maxDrain, space);
             if (flow <= EPSILON_FLOW) continue;
+
+            // Do not flow if there isn't enough budget
+            if (flow > fluidBudget[fluidType]) continue;
 
             if (actor.fluidContainer.outflow && entity.fluidContainer.inflow) {
               // Apply deltas


### PR DESCRIPTION
rats upon death would bleed out but their origin (below corpse) would empty out entirely. This fixes that and adds a tuner for pool shape. Currently hard coded to pretty irregular but can be adjusted as needed later.

- closes #68 